### PR TITLE
Center brand name and adjust hero image

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,10 @@
   <body class="font-sans relative min-h-screen bg-gray-100">
     <!-- Header -->
     <header
-      class="absolute top-0 left-0 w-full flex items-center justify-between px-8 lg:px-14 py-6 z-20"
+      class="absolute top-0 left-0 w-full flex items-center justify-center py-6 z-20"
     >
       <!-- Logo -->
       <a href="#" class="flex items-center space-x-2 select-none">
-        <!-- Simple red maple leaf using an emoji to match the original icon -->
         <span class="text-2xl leading-none">🍁</span>
         <span class="text-lg lg:text-xl font-bold tracking-wide">
           NORTHERN ARMOR
@@ -57,7 +56,7 @@
       </a>
       <!-- Navigation -->
       <nav
-        class="hidden md:flex space-x-6 lg:space-x-8 uppercase text-sm font-medium"
+        class="hidden md:flex space-x-6 lg:space-x-8 uppercase text-sm font-medium absolute right-8 lg:right-14"
       >
         <a href="#" class="nav-link">Jacket</a>
         <a href="#" class="nav-link">Pants</a>
@@ -72,26 +71,27 @@
       <!-- Left side: plain white background -->
       <div class="w-1/2 bg-white"></div>
       <!-- Right side: background image covering entire area -->
+      <div class="w-1/2 bg-gray-900 flex items-center justify-center">
+        <img
+          src="./helmet.jpg"
+          alt="Helmet"
+          class="max-w-full max-h-full object-contain"
+        />
+      </div>
+      <!-- Company name at top center -->
       <div
-        class="w-1/2 bg-gray-900 bg-cover bg-center"
-        style="background-image: url('./helmet.jpg')"
-      ></div>
-      <!-- Company name spanning both sides -->
-      <div
-        class="absolute inset-0 flex items-center justify-center pointer-events-none"
+        class="absolute inset-x-0 top-12 flex justify-center pointer-events-none"
       >
-        <div class="flex w-full">
-          <h1
-            class="w-1/2 text-right pr-4 text-5xl lg:text-6xl font-extrabold text-black"
-          >
-            Northern
-          </h1>
-          <h1
-            class="w-1/2 pl-4 text-5xl lg:text-6xl font-extrabold text-white"
-          >
-            Armor
-          </h1>
-        </div>
+        <h1
+          class="text-5xl lg:text-6xl font-extrabold text-black pr-2"
+        >
+          Northern
+        </h1>
+        <h1
+          class="text-5xl lg:text-6xl font-extrabold text-white pl-2"
+        >
+          Armor
+        </h1>
       </div>
     </section>
   </body>


### PR DESCRIPTION
## Summary
- Center the company name in the header and reposition navigation to the right
- Display helmet image with object-contain to ensure full visibility
- Place company name at the top of the hero section for balanced layout

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ed59bdd4832aa443448c235aedf1