### PR TITLE
Update Enter The Forge link to NeuroJarvis

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
             <div class="p-8 space-y-4">
               <h3 class="text-xl uppercase tracking-[0.14em] font-semibold">Athletics</h3>
               <p class="text-slate-300 text-sm">High-contrast training systems built for resilience and measurable progression.</p>
-              <a href="#" class="inline-block text-xs uppercase tracking-[0.18em] border border-slate-600 px-4 py-2 hover:border-blue-500 hover:text-blue-300 linear-motion duration-200">Enter The Forge</a>
+              <a href="https://neurojarvis.cc/#" class="inline-block text-xs uppercase tracking-[0.18em] border border-slate-600 px-4 py-2 hover:border-blue-500 hover:text-blue-300 linear-motion duration-200">Enter The Forge</a>
             </div>
           </article>
           <article class="division-card rounded-2xl overflow-hidden bg-slate-900/70">


### PR DESCRIPTION
### Motivation
- Replace the placeholder CTA link so the Athletics card's "Enter The Forge" action navigates to the intended external site `https://neurojarvis.cc/#` instead of a `#` anchor.

### Description
- Updated the `href` for the "Enter The Forge" anchor in `index.html` to point to `https://neurojarvis.cc/#`.

### Testing
- Verified the change with `rg` to locate the updated href, served the site with `python -m http.server`, and captured a Playwright screenshot of `http://127.0.0.1:8000/index.html`, all of which completed successfully and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af34666f908323a7d238d4a7062eb8)